### PR TITLE
Add Event ID field to support deduplication

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -613,6 +613,23 @@ scenarios:
 
     runCode(mockData);
     assertApi('gtmOnSuccess').wasCalled();
+- name: No API - Test sendPixel with eventId
+  code: |-
+    const encodeUriComponent = require('encodeUriComponent');
+    const getUrl = require('getUrl');
+    const mockData = {
+      partnerId: '123',
+      conversionId: '12576358',
+      eventId: 'uniqueEventId123'
+    };
+
+    mock('sendPixel', (url, onSuccess, onFailure) => {
+      assertThat(url).contains('https://px.ads.linkedin.com/collect?pid=123&tm=gtmv2&conversionId=12576358&url=' + encodeUriComponent(getUrl()) + '&eventId=uniqueEventId123&v=2&fmt=js&time=');
+      onSuccess();
+    });
+
+    runCode(mockData);
+    assertApi('gtmOnSuccess').wasCalled();
 - name: With API - test script injection
   code: |-
     const getUrl = require('getUrl');
@@ -634,25 +651,6 @@ scenarios:
     \nassertThat(callStack[1]).contains('https://px.ads.linkedin.com/collect?pid=123%2C456%2C789%2C299&tm=gtmv2&conversionId=2&url=google.com&v=2&fmt=js&time=');\n\
     \nassertThat(callStack[2]).contains('https://px.ads.linkedin.com/collect?pid=123%2C456%2C789%2C299&tm=gtmv2&conversionId=3&url=google.com&v=2&fmt=js&time=');\n\
     \nassertApi('gtmOnSuccess').wasCalled();"
-
-- name: No API - Test sendPixel with eventId
-  code: |-
-    const encodeUriComponent = require('encodeUriComponent');
-    const getUrl = require('getUrl');
-    const mockData = {
-      partnerId: '123',
-      conversionId: '12576358',
-      eventId: 'uniqueEventId123'
-    };
-
-    mock('sendPixel', (url, onSuccess, onFailure) => {
-      assertThat(url).contains(https://px.ads.linkedin.com/collect?pid=123&tm=gtmv2&conversionId=12576358&url=' + encodeUriComponent(getUrl()) + '&eventId=uniqueEventId123' + '&v=2&fmt=js&time=');
-      onSuccess();
-    });
-
-    runCode(mockData);
-    assertApi('gtmOnSuccess').wasCalled();
-
 
 ___NOTES___
 

--- a/template.tpl
+++ b/template.tpl
@@ -67,6 +67,14 @@ ___TEMPLATE_PARAMETERS___
     "simpleValueType": true,
     "help": "(Override) This is different than Match rules. Enter a URL only if you were specifically provided one by LinkedIn team to override.",
     "canBeEmptyString": true
+  },
+  {
+    "type": "TEXT",
+    "name": "eventId",
+    "displayName": "Event ID",
+    "simpleValueType": true,
+    "help": "Enter an event id to deduplicate insight tag conversions with Conversions API conversions. The Conversions API conversion to be deduplicated must have the same event id. This field is optional",
+    "canBeEmptyString": true
   }
 ]
 
@@ -91,6 +99,7 @@ const conversionIds = data.conversionId ?
       : '';
 const allPids = [];
 const pageUrl = data.customUrl ? data.customUrl : getUrl();
+const eventId = data.eventId;
 
 /**
  * Checks presence of LinkedIn Insight tag code.
@@ -140,6 +149,7 @@ function generateQueryParamsForGTM(cid) {
   result += '&tm=gtmv2';
   result += cid ? '&conversionId=' + encodeUriComponent(cid) : '';
   result += '&url=' + encodeUriComponent(pageUrl);
+  result += eventId ? '&eventId=' + encodeUriComponent(eventId) : '';
   result += '&v=2&fmt=js&time=' + getTimestamp();
   return result;
 }
@@ -176,6 +186,10 @@ function trackByInsightTag() {
     const lintrk = copyFromWindow('lintrk');
     const options = { tmsource: 'gtmv2' };
     options.conversion_url = pageUrl;
+
+    if (eventId) {
+      options.event_id = eventId;
+    }
 
     if (conversionIds.length && conversionIds.length <= 3) {
       conversionIds.forEach(id => {
@@ -620,6 +634,24 @@ scenarios:
     \nassertThat(callStack[1]).contains('https://px.ads.linkedin.com/collect?pid=123%2C456%2C789%2C299&tm=gtmv2&conversionId=2&url=google.com&v=2&fmt=js&time=');\n\
     \nassertThat(callStack[2]).contains('https://px.ads.linkedin.com/collect?pid=123%2C456%2C789%2C299&tm=gtmv2&conversionId=3&url=google.com&v=2&fmt=js&time=');\n\
     \nassertApi('gtmOnSuccess').wasCalled();"
+
+- name: No API - Test sendPixel with eventId
+  code: |-
+    const encodeUriComponent = require('encodeUriComponent');
+    const getUrl = require('getUrl');
+    const mockData = {
+      partnerId: '123',
+      conversionId: '12576358',
+      eventId: 'uniqueEventId123'
+    };
+
+    mock('sendPixel', (url, onSuccess, onFailure) => {
+      assertThat(url).contains(https://px.ads.linkedin.com/collect?pid=123&tm=gtmv2&conversionId=12576358&url=' + encodeUriComponent(getUrl()) + '&eventId=uniqueEventId123' + '&v=2&fmt=js&time=');
+      onSuccess();
+    });
+
+    runCode(mockData);
+    assertApi('gtmOnSuccess').wasCalled();
 
 
 ___NOTES___


### PR DESCRIPTION
## Summary

Add an Event ID field to support deduplication between Insight Tag and Conversions API events. The insight tag has been extended by passing in an `eventId` query parameter to support this functionality. This PR also extends this template to support passing this field in, so this functionality can be leveraged via GTM.

### Usage:

Since `eventId` must be unique, the recommended approach to use this is by plugging in a [GTM data layer](https://developers.google.com/tag-platform/tag-manager/web/datalayer) variable for this field. 

For page load conversions:

1. Configure GTM variable to read `eventId` from the data layer and plug it into the Event ID field in the template.
2. Push eventId to the data layer before the GTM script executes.
```
window.dataLayer = window.dataLayer || [];
window.dataLayer.push({ eventId: 'xyz' });
```

For event-specific conversions:

1. Configure GTM variable to read `eventId` from the data layer and plug it into the Event ID field in the template.
2. Configure conversion to trigger on a specific GTM event, for eg. `contact`.
2. Push `event` and `eventId` to the data layer on any given user event. 
```
window.dataLayer.push({ event: 'contact', eventId: 'xyz' });
```


## Description

### Background

After the Conversions API beta launch, we may receive the same events from the server and the browser. In such cases, we will have to provide a way to determine which events are the same and keep only one of them. We aim to achieve deduplication by allowing advertisers to pass in an `eventId` query param to be the same for clashing Conversion API and Insight Tag events. The insight tag is extended to support this query param.

A Pixli Tracking Request URL, with the addition of `eventId` will look as follows:

```
https://px.ads.linkedin.com/collect?
v=2
&fmt=js
&pid=49
&time=1597438543703		            // ⟵ Computed
&url=PAGE_URL			            // ⟵ Computed
&eventId=EVENT_ID	                    // ⟵ User Specified
&conversionId=CONVERSION_ID 	   // ⟵ User Specified
&tsmrc=gtmv2 			           // ⟵ Computed, Installation Based
```

The clashing conversions API request for the clashing event must contain the same event id as the request from the insight tag.

### Implementation Details
1. Add an optional field for Event ID to the template
2. Read from `data.eventId` and include it as a query parameter to the tracking request URL if available

## Testing Done
1. Add test for changes and verify in the template editor UI
2. Locally tested changes on test website to ensure query param gets sent

## Screenshots

<img width="823" alt="Screen Shot 2023-04-11 at 9 24 13 AM" src="https://user-images.githubusercontent.com/43223664/231227260-75e411bf-94f7-4b46-974c-d94a4aaab237.png">

<img width="882" alt="Screen Shot 2023-04-11 at 9 09 05 AM" src="https://user-images.githubusercontent.com/43223664/231227058-280c7c4f-3b1a-4c59-a7f7-866a8adb5abe.png">