### PR TITLE
Remove logging permission

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -216,27 +216,6 @@ ___WEB_PERMISSIONS___
   {
     "instance": {
       "key": {
-        "publicId": "logging",
-        "versionId": "1"
-      },
-      "param": [
-        {
-          "key": "environments",
-          "value": {
-            "type": 1,
-            "string": "debug"
-          }
-        }
-      ]
-    },
-    "clientAnnotations": {
-      "isEditedByUser": true
-    },
-    "isRequired": true
-  },
-  {
-    "instance": {
-      "key": {
         "publicId": "send_pixel",
         "versionId": "1"
       },
@@ -614,20 +593,20 @@ scenarios:
 - name: No API - Test sendPixel with eventId
   code: |-
     const encodeUriComponent = require('encodeUriComponent');
-    const getUrl = require('getUrl');
-    const mockData = {
-      partnerId: '123',
-      conversionId: '12576358',
-      eventId: 'uniqueEventId123'
-    };
+        const getUrl = require('getUrl');
+        const mockData = {
+          partnerId: '123',
+          conversionId: '12576358',
+          eventId: 'uniqueEventId123'
+        };
 
-    mock('sendPixel', (url, onSuccess, onFailure) => {
-      assertThat(url).contains('https://px.ads.linkedin.com/collect?pid=123&tm=gtmv2&conversionId=12576358&url=' + encodeUriComponent(getUrl()) + '&eventId=uniqueEventId123&v=2&fmt=js&time=');
-      onSuccess();
-    });
+        mock('sendPixel', (url, onSuccess, onFailure) => {
+          assertThat(url).contains('https://px.ads.linkedin.com/collect?pid=123&tm=gtmv2&conversionId=12576358&url=' + encodeUriComponent(getUrl()) + '&eventId=uniqueEventId123&v=2&fmt=js&time=');
+          onSuccess();
+        });
 
-    runCode(mockData);
-    assertApi('gtmOnSuccess').wasCalled();
+        runCode(mockData);
+        assertApi('gtmOnSuccess').wasCalled();
 - name: With API - test script injection
   code: |-
     const getUrl = require('getUrl');
@@ -649,6 +628,7 @@ scenarios:
     \nassertThat(callStack[1]).contains('https://px.ads.linkedin.com/collect?pid=123%2C456%2C789%2C299&tm=gtmv2&conversionId=2&url=google.com&v=2&fmt=js&time=');\n\
     \nassertThat(callStack[2]).contains('https://px.ads.linkedin.com/collect?pid=123%2C456%2C789%2C299&tm=gtmv2&conversionId=3&url=google.com&v=2&fmt=js&time=');\n\
     \nassertApi('gtmOnSuccess').wasCalled();"
+
 
 ___NOTES___
 


### PR DESCRIPTION
## Summary
The template is running into parse errors:  [template status](https://tagmanager.google.com/gallery/#/template/linkedin/linkedin-gtm-community-template/status). This is due to the following error message:

```
Optional permissions declared as required: logging
```

The error is being thrown because the sandboxed JS template and the permissions needed went out of sync with each other.  The permissions section is auto-generated by GTM by detecting API usages in the JS code. We removed the usage of `logging` in [this commit](https://github.com/linkedin/linkedin-gtm-community-template/commit/0d26029ef0d7e194225ebed4bd57d1ad68ee4216), but the permissions section in the template wasn't updated to reflect the same.

Fix this by re-running the sandboxed JS through the GTM template editor, and performing a fresh export of the template file.

P.S. The formatting changes to the test file are a result of exporting a fresh template from the GTM template editor.

## Testing Done
- Local testing, ensure that the `template.tpl` file is the same as the one generated by GTM
