### PR TITLE
Fix tests

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,8 +1,8 @@
 homepage: "https://linkedin.com/campaignmanager"
 documentation: "https://www.linkedin.com/help/lms/answer/a416960"
 versions:
-  - sha: 8f8b426c59a5fd19778cff8dd6433caab57c5699
-    changeNotes: Fixed failed tests
+  - sha: f0e6a713f3472cba97898ad87c12e991e685bd7e
+    changeNotes: Fixed failed tests and also fix intilize tag issue
   - sha: d6d31ee6f8880ffd8037e4aea7146ccd7cbba27b
     changeNotes: Add condition to validate insight tag is loading only once
   - sha: c7e2513ed82b4cf2110c3ece43132c04ea90270c

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://linkedin.com/campaignmanager"
 documentation: "https://www.linkedin.com/help/lms/answer/a416960"
 versions:
+  - sha: 8f8b426c59a5fd19778cff8dd6433caab57c5699
+    changeNotes: Fixed failed tests
   - sha: d6d31ee6f8880ffd8037e4aea7146ccd7cbba27b
     changeNotes: Add condition to validate insight tag is loading only once
   - sha: c7e2513ed82b4cf2110c3ece43132c04ea90270c

--- a/template.tpl
+++ b/template.tpl
@@ -1,12 +1,4 @@
-﻿___TERMS_OF_SERVICE___
-
-By creating or modifying this file you agree to Google Tag Manager's Community
-Template Gallery Developer Terms of Service available at
-https://developers.google.com/tag-manager/gallery-tos (or such other URL as
-Google may provide), as modified from time to time.
-
-
-___INFO___
+﻿___INFO___
 
 {
   "type": "TAG",
@@ -93,6 +85,7 @@ const getTimestamp = require('getTimestamp');
 const injectScript = require('injectScript');
 const copyFromWindow = require('copyFromWindow');
 const encodeUriComponent = require('encodeUriComponent');
+const callLater = require('callLater');
 
 /**
  * Globals
@@ -161,7 +154,10 @@ function generateQueryParamsForGTM(cid) {
 
 // Success call back to InsightTag injection
 function didInjectInsightTag() {
+  callLater(() => {
   trackByInsightTag();
+});
+  
 }
 
 // Callback to plain GTM when InsightTag code failed to inject
@@ -661,6 +657,12 @@ scenarios:
       }
     });
 
+    let isTrackedByInsightTag = false;
+
+    mock('callLater', () => {
+      isTrackedByInsightTag = true;
+    });
+
     mock('injectScript', function(url, onSuccess, onFailure) {
       assertThat(url).isEqualTo('https://snap.licdn.com/li.lms-analytics/insight.min.js');
       onSuccess();
@@ -670,7 +672,7 @@ scenarios:
     runCode(mockData);
 
     assertApi('injectScript').wasCalled(1);
-    assertApi('gtmOnSuccess').wasCalled();
+    assertThat(isTrackedByInsightTag).isTrue();
 
 
 ___NOTES___

--- a/template.tpl
+++ b/template.tpl
@@ -212,10 +212,6 @@ function trackByInsightTag() {
   }
 }
 
-/**
- * Enable `trackByPlainGTM` for test purposes, and disable `trackByInsightTag`.
- * trackByPlainGTM();
- */
 trackByInsightTag();
 
 
@@ -579,6 +575,10 @@ scenarios:
       conversionId: '12576358'
     };
 
+    mock('injectScript', function(url, onSuccess, onFailure) {
+      onFailure();
+    });
+
     mock('sendPixel', (url, onSuccess, onFailure) => {
       assertThat(url).contains('https://px.ads.linkedin.com/collect?pid=123&tm=gtmv2&conversionId=12576358&url=google.com&v=2&fmt=js&time=');
       onSuccess();
@@ -591,6 +591,10 @@ scenarios:
     const encodeUriComponent = require('encodeUriComponent');
     const getUrl = require('getUrl');
     const mockData = { partnerId: '123' };
+
+    mock('injectScript', function(url, onSuccess, onFailure) {
+      onFailure();
+    });
 
     mock('sendPixel', (url, onSuccess, onFailure) => {
       assertThat(url).contains('https://px.ads.linkedin.com/collect?pid=123&tm=gtmv2&url=' + encodeUriComponent(getUrl()) + '&v=2&fmt=js&time=');
@@ -609,7 +613,11 @@ scenarios:
           eventId: 'uniqueEventId123'
         };
 
-        mock('sendPixel', (url, onSuccess, onFailure) => {
+    mock('injectScript', function(url, onSuccess, onFailure) {
+      onFailure();
+    });
+
+    mock('sendPixel', (url, onSuccess, onFailure) => {
           assertThat(url).contains('https://px.ads.linkedin.com/collect?pid=123&tm=gtmv2&conversionId=12576358&url=' + encodeUriComponent(getUrl()) + '&eventId=uniqueEventId123&v=2&fmt=js&time=');
           onSuccess();
         });
@@ -629,7 +637,8 @@ scenarios:
     runCode(mockData);
 - name: No API - Multiple partnerIds and conversion ids
   code: "const mockData = {\n  partnerId: '123,456, 789, 299',\n  customUrl: 'google.com',\n\
-    \  conversionId: '1, 2, 3, 4, 5'\n};\nconst callStack = [];\nmock('sendPixel',\
+    \  conversionId: '1, 2, 3, 4, 5'\n};\nconst callStack = [];\n\nmock('injectScript',\
+    \ function(url, onSuccess, onFailure) {\n  onFailure();\n});\n\nmock('sendPixel',\
     \ (url, onSuccess, onFailure) => {\n  callStack.push(url);\n  \n  // Call success\
     \ only once when stack is full\n  if (callStack.length === 3) {\n    onSuccess();\n\
     \  }\n});\n\nrunCode(mockData);\n\nassertThat(callStack.length).isEqualTo(3);\n\


### PR DESCRIPTION
Some tests that mock the sendPixel failed. The reason is that, with the current template flow, it sends sendPixel events only after the injection of the script has failed. Therefore, I needed to intentionally fail the injection in each place where we were attempting to send a pixel event.