### PR TITLE
Add GTM agreement

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://linkedin.com/campaignmanager"
 documentation: "https://www.linkedin.com/help/lms/answer/a416960"
 versions:
+  - sha: c07099c0e0cf0ade2057ee4016d3da9f32959169
+    changeNotes: Adding google tag manager terms of service
   - sha: f0e6a713f3472cba97898ad87c12e991e685bd7e
     changeNotes: Fixed failed tests and also fix intilize tag issue
   - sha: d6d31ee6f8880ffd8037e4aea7146ccd7cbba27b

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,12 @@
-﻿___INFO___
+﻿___TERMS_OF_SERVICE___
+
+By creating or modifying this file you agree to Google Tag Manager's Community
+Template Gallery Developer Terms of Service available at
+https://developers.google.com/tag-manager/gallery-tos (or such other URL as
+Google may provide), as modified from time to time.
+
+
+___INFO___
 
 {
   "type": "TAG",


### PR DESCRIPTION
The last upload of the tag failed because it did not include the GTM terms of service agreement. This PR fixes it.






